### PR TITLE
Remove registering LocalAuthority

### DIFF
--- a/lib/hydra/datastreams/collection_rdf_datastream.rb
+++ b/lib/hydra/datastreams/collection_rdf_datastream.rb
@@ -67,12 +67,5 @@ module Hydra
       end
       map.related_url(:to => "seeAlso", :in => RDF::RDFS)
     end
-    begin
-      LocalAuthority.register_vocabulary(self, "subject", "lc_subjects")
-      LocalAuthority.register_vocabulary(self, "language", "lexvo_languages")
-      LocalAuthority.register_vocabulary(self, "tag", "lc_genres")
-    rescue
-      puts "tables for vocabularies missing"
-    end
   end
 end


### PR DESCRIPTION
This code was always erroring with `uninitialized constant
Hydra::CollectionRdfDatastream::LocalAuthority` and giving a misleading
warning.
