### PR TITLE
Allowing the collection class to be of any name

### DIFF
--- a/lib/hydra/collections/collectible.rb
+++ b/lib/hydra/collections/collectible.rb
@@ -6,7 +6,7 @@ module Hydra::Collections::Collectible
   
   included do
     #after_solrize << :index_collection_pids
-    has_many :collections, property: :has_collection_member
+    has_many :collections, property: :has_collection_member, :class_name => "ActiveFedora::Base"
   end
 
   # Add this method to your solrization logic (ie. in to_solr) in order to populate the 'collection' facet 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -97,4 +97,32 @@ describe Collection do
     GenericFile.exists?(@gf1.pid).should be_true
     GenericFile.exists?(@gf2.pid).should be_true
   end
+
+  describe "Collection by another name" do
+    before (:all) do
+      class OtherCollection < ActiveFedora::Base
+        include Hydra::Collection
+        include Hydra::Collections::Collectible
+      end
+      class Member < ActiveFedora::Base
+        include Hydra::Collections::Collectible
+      end
+    end
+    after(:all) do
+      Object.send(:remove_const, :OtherCollection)
+      Object.send(:remove_const, :Member)
+    end
+
+    it "have members that know about the collection" do
+      collection = OtherCollection.new
+      member = Member.create
+      collection.members << member
+      collection.save
+      member.reload
+      member.collections.should == [collection]
+      collection.destroy
+      member.destroy
+    end
+  end
+
 end


### PR DESCRIPTION
When the collection class name was not collection an error about type miss-match occurred:
 ActiveFedora::AssociationTypeMismatch:
       Collection(#70133778381500) expected, got OtherCollection(#70133756435420)

This allows the collection class to be any ActiveFedora::Base class.
