### PR TITLE
Changed member inclusion in a collection to use the collection model ins...

### DIFF
--- a/app/controllers/concerns/hydra/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hydra/collections_controller_behavior.rb
@@ -178,12 +178,7 @@ module Hydra
     # include filters into the query to only include the collection memebers
     def include_collection_ids(solr_parameters, user_parameters)
       solr_parameters[:fq] ||= []
-      if @collection.member_ids.empty?
-        solr_parameters[:fq] << '{!lucene}-id:[* TO *]' # Don't match anything
-      else
-        query = @collection.member_ids.map{|id| 'id:"'+id+'"'}.join " OR "
-        solr_parameters[:fq] << query
-      end
+      solr_parameters[:fq] << Solrizer.solr_name(:collection)+':"'+@collection.id+'"'
     end
   end # module CollectionsControllerBehavior
 end # module Hydra

--- a/spec/controllers/other_collections_controller_spec.rb
+++ b/spec/controllers/other_collections_controller_spec.rb
@@ -13,10 +13,23 @@ end
 class OtherCollection < ActiveFedora::Base
   include Hydra::Collection
   include Hydra::Collections::Collectible
+
+  def to_solr(solr_doc={}, opts={})
+    super(solr_doc, opts)
+    solr_doc = index_collection_pids(solr_doc)
+    return solr_doc
+  end
+
 end
 class Member < ActiveFedora::Base
   include Hydra::Collections::Collectible
   attr_accessor :title
+
+  def to_solr(solr_doc={}, opts={})
+    super(solr_doc, opts)
+    solr_doc = index_collection_pids(solr_doc)
+    return solr_doc
+  end
 
 end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -18,6 +18,14 @@ describe Collection do
   before(:all) do
     @user = FactoryGirl.find_or_create(:user)
     class GenericFile < ActiveFedora::Base
+      include Hydra::Collections::Collectible
+
+      def to_solr(solr_doc={}, opts={})
+        super(solr_doc, opts)
+        solr_doc = index_collection_pids(solr_doc)
+        return solr_doc
+      end
+
     end
   end
   after(:all) do
@@ -73,6 +81,9 @@ describe Collection do
     @collection.members = [@gf1]
     @collection.save
     @collection.date_modified.should == modified_date
+    @gf1 = @gf1.reload
+    @gf1.collections.should include(@collection)
+    @gf1.to_solr[Solrizer.solr_name(:collection)].should == [@collection.id]
   end
   it "should have a title" do
     @collection.title = "title"


### PR DESCRIPTION
...tead of each id in the solr query.

The one thing to note is the old way worked even if you were not using index_collection_pids in the model to_solr, but you could only have a limited number of items in the collection before the http query got too long
