### PR TITLE
update to rspec3

### DIFF
--- a/hydra-collections.gemspec
+++ b/hydra-collections.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec-rails", '~> 2.99'
+  spec.add_development_dependency "rspec-rails"
 end

--- a/spec/controllers/accepts_batches_spec.rb
+++ b/spec/controllers/accepts_batches_spec.rb
@@ -4,23 +4,24 @@ class AcceptsBatchesController < ApplicationController
   include Hydra::Collections::AcceptsBatches
 end
 
-describe AcceptsBatchesController do
+describe AcceptsBatchesController, :type => :controller do
 
   describe "batch" do
     it "should accept batch from parameters" do
       controller.params["batch_document_ids"] = ["abc", "xyz"]
-      controller.batch.should == ["abc", "xyz"]
+      expect(controller.batch).to eq(["abc", "xyz"])
     end
     describe ":all" do
+      let(:current_user) { double(user_key: 'vanessa') }
       before do
         doc1 = double(:id=>123)
         doc2 = double(:id=>456)
-        Hydra::Collections::SearchService.any_instance.should_receive(:last_search_documents).and_return([doc1, doc2])
-        controller.stub(current_user: double(user_key: 'vanessa'))
+        expect_any_instance_of(Hydra::Collections::SearchService).to receive(:last_search_documents).and_return([doc1, doc2])
+        allow(controller).to receive(:current_user).and_return(current_user)
       end
       it "should add every document in the current resultset to the batch" do
         controller.params["batch_document_ids"] = "all"
-        controller.batch.should == [123, 456]
+        expect(controller.batch).to eq([123, 456])
       end
     end
   end
@@ -32,39 +33,36 @@ describe AcceptsBatchesController do
       subject.batch = @allowed + @disallowed
     end
     it "using filter_docs_with_access!" do
-      @allowed.each {|doc_id| subject.should_receive(:can?).with(:foo, doc_id).and_return(true)}
-      @disallowed.each {|doc_id| subject.should_receive(:can?).with(:foo, doc_id).and_return(false)}
+      @allowed.each {|doc_id| expect(subject).to receive(:can?).with(:foo, doc_id).and_return(true)}
+      @disallowed.each {|doc_id| expect(subject).to receive(:can?).with(:foo, doc_id).and_return(false)}
       subject.send(:filter_docs_with_access!, :foo)
-      subject.batch.should
-      flash[:notice].should == "You do not have permission to edit the documents: #{@disallowed.join(', ')}"
+      expect(flash[:notice]).to eq("You do not have permission to edit the documents: #{@disallowed.join(', ')}")
     end
     it "using filter_docs_with_edit_access!" do
-      @allowed.each {|doc_id| subject.should_receive(:can?).with(:edit, doc_id).and_return(true)}
-      @disallowed.each {|doc_id| subject.should_receive(:can?).with(:edit, doc_id).and_return(false)}
+      @allowed.each {|doc_id| expect(subject).to receive(:can?).with(:edit, doc_id).and_return(true)}
+      @disallowed.each {|doc_id| expect(subject).to receive(:can?).with(:edit, doc_id).and_return(false)}
       subject.send(:filter_docs_with_edit_access!)
-      subject.batch.should
-      flash[:notice].should == "You do not have permission to edit the documents: #{@disallowed.join(', ')}"
+      expect(flash[:notice]).to eq("You do not have permission to edit the documents: #{@disallowed.join(', ')}")
     end
     it "using filter_docs_with_read_access!" do
-      @allowed.each {|doc_id| subject.should_receive(:can?).with(:read, doc_id).and_return(true)}
-      @disallowed.each {|doc_id| subject.should_receive(:can?).with(:read, doc_id).and_return(false)}
+      @allowed.each {|doc_id| expect(subject).to receive(:can?).with(:read, doc_id).and_return(true)}
+      @disallowed.each {|doc_id| expect(subject).to receive(:can?).with(:read, doc_id).and_return(false)}
       subject.send(:filter_docs_with_read_access!)
-      subject.batch.should
-      flash[:notice].should == "You do not have permission to edit the documents: #{@disallowed.join(', ')}"
+      expect(flash[:notice]).to eq("You do not have permission to edit the documents: #{@disallowed.join(', ')}")
     end
     it "and be sassy if you didn't select anything" do
       subject.batch = []
       subject.send(:filter_docs_with_read_access!)
-      flash[:notice].should == "Select something first"
+      expect(flash[:notice]).to eq("Select something first")
     end
     
   end
     
   it "should check for empty" do
     controller.batch = ["77826928", "94120425"]
-    controller.check_for_empty_batch?.should == false
+    expect(controller.check_for_empty_batch?).to eq(false)
     controller.batch = []
-    controller.check_for_empty_batch?.should == true
+    expect(controller.check_for_empty_batch?).to eq(true)
   end
 
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -16,9 +16,9 @@ require 'spec_helper'
 
 include Rails.application.routes.url_helpers
 
-describe CatalogController do
+describe CatalogController, :type => :controller do
   before do
-    controller.stub(:has_access?).and_return(true)
+    allow(controller).to receive(:has_access?).and_return(true)
     @user = FactoryGirl.find_or_create(:user)
     @collection = Collection.new title:"Test"
     @collection.apply_depositor_metadata(@user.user_key)
@@ -37,7 +37,7 @@ describe CatalogController do
       @routes = Rails.application.routes
       get :index
       expect(assigns(:user_collections)).to be_kind_of(Array)
-      assigns(:user_collections).index{|d| d.id == @collection.id}.should_not be_nil
+      expect(assigns(:user_collections).index{|d| d.id == @collection.id}).not_to be_nil
     end
   end
   

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CollectionsController do
+describe CollectionsController, :type => :controller do
   before(:all) do
     @user = FactoryGirl.find_or_create(:user)
 #    CollectionsController.config.default_solr_params = {:qf => 'title_tesim'}
@@ -25,12 +25,12 @@ describe CollectionsController do
   end
   
   before do
-    controller.stub(:has_access?).and_return(true)
+    allow(controller).to receive(:has_access?).and_return(true)
 
     @user = FactoryGirl.find_or_create(:user)
     sign_in @user
-    User.any_instance.stub(:groups).and_return([])
-    controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+    allow_any_instance_of(User).to receive(:groups).and_return([])
+    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
   end
 
   describe '#new' do
@@ -39,9 +39,9 @@ describe CollectionsController do
       expect(assigns(:collection)).to be_kind_of(Collection)
     end
     it "should pass through batch ids if provided and stick them in the form" do
-      pending "Couldn't get have_selector working before I had to move on.  - MZ"
+      skip "Couldn't get have_selector working before I had to move on.  - MZ"
       get :new, batch_document_ids: ["test2", "test88"]
-      response.should have_selector("p[class='foo']")
+      expect(response).to have_selector("p[class='foo']")
     end
   end
   
@@ -49,45 +49,45 @@ describe CollectionsController do
     it "should create a Collection" do
       old_count = Collection.count
       post :create, collection: {title: "My First Collection ", description: "The Description\r\n\r\nand more"}
-      Collection.count.should == old_count+1
-      assigns[:collection].title.should == "My First Collection "
-      assigns[:collection].description.should == "The Description\r\n\r\nand more"
-      assigns[:collection].depositor.should == @user.user_key
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(assigns[:collection].id)
+      expect(Collection.count).to eq(old_count+1)
+      expect(assigns[:collection].title).to eq("My First Collection ")
+      expect(assigns[:collection].description).to eq("The Description\r\n\r\nand more")
+      expect(assigns[:collection].depositor).to eq(@user.user_key)
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(assigns[:collection].id)
     end
     it "should add docs to collection if batch ids provided" do
       @asset1 = ActiveFedora::Base.create!
       @asset2 = ActiveFedora::Base.create!
       post :create, batch_document_ids: [@asset1, @asset2], collection: {title: "My Secong Collection ", description: "The Description\r\n\r\nand more"}
-      assigns[:collection].members.should == [@asset1, @asset2]
+      expect(assigns[:collection].members).to eq([@asset1, @asset2])
     end
     it "should call after_create" do
-       controller.should_receive(:after_create).and_call_original
+       expect(controller).to receive(:after_create).and_call_original
        post :create, collection: {title: "My First Collection ", description: "The Description\r\n\r\nand more"}
     end
 
     it "should add one doc to collection if batch ids provided and add the collection id to the document in the colledction" do
       @asset1 = GenericFile.create!
       post :create, batch_document_ids: [@asset1], collection: {title: "My Secong Collection ", description: "The Description\r\n\r\nand more"}
-      assigns[:collection].members.should == [@asset1]
+      expect(assigns[:collection].members).to eq([@asset1])
       asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset1.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
-      asset_results["response"]["numFound"].should == 1
+      expect(asset_results["response"]["numFound"]).to eq(1)
       doc = asset_results["response"]["docs"].first
-      doc["id"].should == @asset1.pid
+      expect(doc["id"]).to eq(@asset1.pid)
       afterupdate = GenericFile.find(@asset1.pid)
-      doc[Solrizer.solr_name(:collection)].should == afterupdate.to_solr[Solrizer.solr_name(:collection)]
+      expect(doc[Solrizer.solr_name(:collection)]).to eq(afterupdate.to_solr[Solrizer.solr_name(:collection)])
     end
     it "should add docs to collection if batch ids provided and add the collection id to the documents int he colledction" do
       @asset1 = GenericFile.create!
       @asset2 = GenericFile.create!
       post :create, batch_document_ids: [@asset1,@asset2], collection: {title: "My Secong Collection ", description: "The Description\r\n\r\nand more"}
-      assigns[:collection].members.should == [@asset1,@asset2]
+      expect(assigns[:collection].members).to eq([@asset1,@asset2])
       asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset1.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
-      asset_results["response"]["numFound"].should == 1
+      expect(asset_results["response"]["numFound"]).to eq(1)
       doc = asset_results["response"]["docs"].first
-      doc["id"].should == @asset1.pid
+      expect(doc["id"]).to eq(@asset1.pid)
       afterupdate = GenericFile.find(@asset1.pid)
-      doc[Solrizer.solr_name(:collection)].should == afterupdate.to_solr[Solrizer.solr_name(:collection)]
+      expect(doc[Solrizer.solr_name(:collection)]).to eq(afterupdate.to_solr[Solrizer.solr_name(:collection)])
     end
   end
 
@@ -99,76 +99,76 @@ describe CollectionsController do
       @asset1 = GenericFile.create!
       @asset2 = GenericFile.create!
       @asset3 = GenericFile.create!
-      controller.stub(:authorize!).and_return(true)
-      controller.should_receive(:authorize!).at_least(:once)
+      allow(controller).to receive(:authorize!).and_return(true)
+      expect(controller).to receive(:authorize!).at_least(:once)
     end
     it "should update collection metadata" do
       put :update, id: @collection.id, collection: {title: "New Title", description: "New Description"}
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
-      assigns[:collection].title.should == "New Title"
-      assigns[:collection].description.should == "New Description"
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
+      expect(assigns[:collection].title).to eq("New Title")
+      expect(assigns[:collection].description).to eq("New Description")
     end
 
     it "should call after_update" do
-       controller.should_receive(:after_update).and_call_original
+       expect(controller).to receive(:after_update).and_call_original
        put :update, id: @collection.id, collection: {title: "New Title", description: "New Description"}
     end
     it "should support adding batches of members" do
       @collection.members << @asset1
       @collection.save
       put :update, id: @collection.id, collection: {members:"add"}, batch_document_ids:[@asset2, @asset3]
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
-      assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }.should == [@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid }
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
+      expect(assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }).to eq([@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid })
     end
     it "should support removing batches of members" do
       @collection.members = [@asset1, @asset2, @asset3]
       @collection.save
       put :update, id: @collection.id, collection: {members:"remove"}, batch_document_ids:[@asset1, @asset3]
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
-      assigns[:collection].members.should == [@asset2]
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
+      expect(assigns[:collection].members).to eq([@asset2])
     end
     it "should support setting members array" do
       put :update, id: @collection.id, collection: {members:"add"}, batch_document_ids:[@asset2, @asset3, @asset1]
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
-      assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }.should == [@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid }
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
+      expect(assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }).to eq([@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid })
     end
     it "should support setting members array" do
       put :update, id: @collection.id, collection: {members:"add"}, batch_document_ids:[@asset2, @asset3, @asset1]
-      response.should redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
-      assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }.should == [@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid }
+      expect(response).to redirect_to Hydra::Collections::Engine.routes.url_helpers.collection_path(@collection.id)
+      expect(assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }).to eq([@asset2, @asset3, @asset1].sort! { |a,b| a.pid <=> b.pid })
     end
     it "should set/un-set collection on members" do
       # Add to collection (sets collection on members)
       solr_doc_before_add = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @asset2.pid).send(:solr_doc)
-      solr_doc_before_add[Solrizer.solr_name(:collection)].should be_nil
+      expect(solr_doc_before_add[Solrizer.solr_name(:collection)]).to be_nil
       put :update, id: @collection.id, collection: {members:"add"}, batch_document_ids:[@asset2, @asset3]
-      assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }.should == [@asset2, @asset3].sort! { |a,b| a.pid <=> b.pid }
+      expect(assigns[:collection].members.sort! { |a,b| a.pid <=> b.pid }).to eq([@asset2, @asset3].sort! { |a,b| a.pid <=> b.pid })
       ## Check that member lists collection in its solr doc
       @asset2.reload
-      @asset2.to_solr[Solrizer.solr_name(:collection)].should == [@collection.pid]
+      expect(@asset2.to_solr[Solrizer.solr_name(:collection)]).to eq([@collection.pid])
       ## Check that member was re-indexed with collection info
       asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset2.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
       doc = asset_results["response"]["docs"].first
-      doc["id"].should == @asset2.pid
-      doc[Solrizer.solr_name(:collection)].should == [@collection.pid]
+      expect(doc["id"]).to eq(@asset2.pid)
+      expect(doc[Solrizer.solr_name(:collection)]).to eq([@collection.pid])
       solr_doc_after_add = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @asset2.pid).send(:solr_doc)
-      solr_doc_after_add[Solrizer.solr_name(:collection)].should == [@collection.pid]
+      expect(solr_doc_after_add[Solrizer.solr_name(:collection)]).to eq([@collection.pid])
 
       # Remove from collection (un-sets collection on members)
       solr_doc_before_remove = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @asset2.pid).send(:solr_doc)
-      solr_doc_before_remove[Solrizer.solr_name(:collection)].should == [@collection.pid]
+      expect(solr_doc_before_remove[Solrizer.solr_name(:collection)]).to eq([@collection.pid])
       put :update, id: @collection.id, collection: {members:"remove"}, batch_document_ids:[@asset2]
-      assigns[:collection].members.should_not include(@asset2)
+      expect(assigns[:collection].members).not_to include(@asset2)
       ## Check that member no longer lists collection in its solr doc
       @asset2.reload
-      @asset2.to_solr[Solrizer.solr_name(:collection)].should == []
+      expect(@asset2.to_solr[Solrizer.solr_name(:collection)]).to eq([])
       ## Check that member was re-indexed without collection info
       asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset2.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
       doc = asset_results["response"]["docs"].first
-      doc["id"].should == @asset2.pid
-      doc[Solrizer.solr_name(:collection)].should be_nil
+      expect(doc["id"]).to eq(@asset2.pid)
+      expect(doc[Solrizer.solr_name(:collection)]).to be_nil
       solr_doc_after_remove = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @asset2.pid).send(:solr_doc)
-      solr_doc_after_remove[Solrizer.solr_name(:collection)].should be_nil
+      expect(solr_doc_after_remove[Solrizer.solr_name(:collection)]).to be_nil
     end
     
     it "should allow moving members between collections" do
@@ -178,8 +178,8 @@ describe CollectionsController do
       @collection2.apply_depositor_metadata(@user.user_key)
       @collection2.save
       put :update, id: @collection.id, collection: {members:"move"}, destination_collection_id:@collection2.pid, batch_document_ids:[@asset2, @asset3]
-      ::Collection.find(@collection.pid).members.should == [@asset1]
-      ::Collection.find(@collection2.pid).members.should == [@asset2, @asset3]
+      expect(::Collection.find(@collection.pid).members).to eq([@asset1])
+      expect(::Collection.find(@collection2.pid).members).to eq([@asset2, @asset3])
     end
 
   end
@@ -190,15 +190,15 @@ describe CollectionsController do
         @collection = Collection.new
         @collection.apply_depositor_metadata(@user.user_key)
         @collection.save
-        controller.should_receive(:authorize!).and_return(true)
+        expect(controller).to receive(:authorize!).and_return(true)
       end
       it "should delete collection" do
         delete :destroy, id: @collection.id
-        response.should redirect_to Rails.application.routes.url_helpers.catalog_index_path
-        flash[:notice].should == "Collection was successfully deleted."
+        expect(response).to redirect_to Rails.application.routes.url_helpers.catalog_index_path
+        expect(flash[:notice]).to eq("Collection was successfully deleted.")
       end
       it "should after_destroy" do
-        controller.should_receive(:after_destroy).and_call_original
+        expect(controller).to receive(:after_destroy).and_call_original
         delete :destroy, id: @collection.id
       end
       it "should call update members" do
@@ -207,18 +207,18 @@ describe CollectionsController do
         @collection.save
         @asset1 = @asset1.reload
         @asset1.update_index
-        @asset1.collections.should == [@collection]
+        expect(@asset1.collections).to eq([@collection])
         asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset1.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
-        asset_results["response"]["numFound"].should == 1
+        expect(asset_results["response"]["numFound"]).to eq(1)
         doc = asset_results["response"]["docs"].first
-        doc[Solrizer.solr_name(:collection)].should == [@collection.pid]
+        expect(doc[Solrizer.solr_name(:collection)]).to eq([@collection.pid])
 
         delete :destroy, id: @collection.id
-        @asset1.reload.collections.should == []
+        expect(@asset1.reload.collections).to eq([])
         asset_results = blacklight_solr.get "select", params:{fq:["id:\"#{@asset1.pid}\""],fl:['id',Solrizer.solr_name(:collection)]}
-        asset_results["response"]["numFound"].should == 1
+        expect(asset_results["response"]["numFound"]).to eq(1)
         doc = asset_results["response"]["docs"].first
-        doc[Solrizer.solr_name(:collection)].should be_nil
+        expect(doc[Solrizer.solr_name(:collection)]).to be_nil
         @asset1.destroy
       end
     end
@@ -237,16 +237,16 @@ describe CollectionsController do
       @collection.apply_depositor_metadata(@user.user_key)
       @collection.members = [@asset1,@asset2,@asset3]
       @collection.save
-      controller.stub(:authorize!).and_return(true)
-      controller.stub(:apply_gated_search)
+      allow(controller).to receive(:authorize!).and_return(true)
+      allow(controller).to receive(:apply_gated_search)
     end
     it "should show the collections" do
       get :show, id: @collection.id
-      assigns[:collection].title.should == @collection.title
+      expect(assigns[:collection].title).to eq(@collection.title)
       ids = assigns[:member_docs].map {|d| d.id}
-      ids.should include @asset1.pid
-      ids.should include @asset2.pid
-      ids.should include @asset3.pid
+      expect(ids).to include @asset1.pid
+      expect(ids).to include @asset2.pid
+      expect(ids).to include @asset3.pid
     end
     context "when items have been added and removed" do
       it "should return the items that are in the collection and not return items that have been removed" do
@@ -269,46 +269,46 @@ describe CollectionsController do
         @collection2.members = [@asset4]
         @collection2.save
         @asset4 = @asset4.reload
-        @asset4.collections.should == [@collection2]
+        expect(@asset4.collections).to eq([@collection2])
       end
 
       it "should show only the collections assets" do
         get :show, id: @collection.pid
-        assigns[:collection].title.should == @collection.title
+        expect(assigns[:collection].title).to eq(@collection.title)
         ids = assigns[:member_docs].map {|d| d.id}
-        ids.should include @asset1.pid
-        ids.should include @asset2.pid
-        ids.should include @asset3.pid
-        ids.should_not include @asset4.pid
+        expect(ids).to include @asset1.pid
+        expect(ids).to include @asset2.pid
+        expect(ids).to include @asset3.pid
+        expect(ids).not_to include @asset4.pid
 
       end
       it "should show only the other collections assets" do
 
         get :show, id: @collection2.pid
-        assigns[:collection].title.should == @collection2.title
+        expect(assigns[:collection].title).to eq(@collection2.title)
         ids = assigns[:member_docs].map {|d| d.id}
-        ids.should_not include @asset1.pid
-        ids.should_not include @asset2.pid
-        ids.should_not include @asset3.pid
-        ids.should include @asset4.pid
+        expect(ids).not_to include @asset1.pid
+        expect(ids).not_to include @asset2.pid
+        expect(ids).not_to include @asset3.pid
+        expect(ids).to include @asset4.pid
 
       end
     end
 
     it "when the collection is empty it should show no assets" do
       get :show, id: Collection.create(title: "Empty collection").id
-      assigns[:collection].title.should ==  "Empty collection"
-      assigns[:member_docs].should be_empty
+      expect(assigns[:collection].title).to eq("Empty collection")
+      expect(assigns[:member_docs]).to be_empty
     end
 
     # NOTE: This test depends on title_tesim being in the qf in solrconfig.xml
     it "should query the collections" do
       get :show, id: @collection.id, cq:"\"#{@asset1.title}\""
-      assigns[:collection].title.should == @collection.title
+      expect(assigns[:collection].title).to eq(@collection.title)
       ids = assigns[:member_docs].map {|d| d.id}
-      ids.should include @asset1.pid
-      ids.should_not include @asset2.pid
-      ids.should_not include @asset3.pid
+      expect(ids).to include @asset1.pid
+      expect(ids).not_to include @asset2.pid
+      expect(ids).not_to include @asset3.pid
     end
 
     # NOTE: This test depends on title_tesim being in the qf in solrconfig.xml
@@ -316,20 +316,20 @@ describe CollectionsController do
       @asset4 = GenericFile.create!(title: "#{@asset1.id} #{@asset1.title}")
       @asset5 = GenericFile.create!(title: "#{@asset1.title}")
       get :show, id: @collection.id, cq:"\"#{@asset1.title}\""
-      assigns[:collection].title.should == @collection.title
+      expect(assigns[:collection].title).to eq(@collection.title)
       ids = assigns[:member_docs].map {|d| d.id}
-      ids.should include @asset1.pid
-      ids.should_not include @asset2.pid
-      ids.should_not include @asset3.pid
-      ids.should_not include @asset4.pid
-      ids.should_not include @asset5.pid
+      expect(ids).to include @asset1.pid
+      expect(ids).not_to include @asset2.pid
+      expect(ids).not_to include @asset3.pid
+      expect(ids).not_to include @asset4.pid
+      expect(ids).not_to include @asset5.pid
     end
 
     it "should query the collections with rows" do
       get :show, id: @collection.id, rows:"2"
-      assigns[:collection].title.should == @collection.title
+      expect(assigns[:collection].title).to eq(@collection.title)
       ids = assigns[:member_docs].map {|d| d.id}
-      ids.count.should == 2
+      expect(ids.count).to eq(2)
     end
 
   end

--- a/spec/controllers/other_collections_controller_spec.rb
+++ b/spec/controllers/other_collections_controller_spec.rb
@@ -34,7 +34,7 @@ class Member < ActiveFedora::Base
 end
 
 # make sure a collection by another name still assigns the @collection variable
-describe OtherCollectionsController do
+describe OtherCollectionsController, :type => :controller do
   before(:all) do
     @user = FactoryGirl.find_or_create(:user)
   end
@@ -49,12 +49,12 @@ describe OtherCollectionsController do
   end
   
   before do
-    controller.stub(:has_access?).and_return(true)
+    allow(controller).to receive(:has_access?).and_return(true)
 
     @user = FactoryGirl.find_or_create(:user)
     sign_in @user
-    User.any_instance.stub(:groups).and_return([])
-    controller.stub(:clear_session_user) ## Don't clear out the authenticated session
+    allow_any_instance_of(User).to receive(:groups).and_return([])
+    allow(controller).to receive(:clear_session_user) ## Don't clear out the authenticated session
   end
 
   describe "#show" do
@@ -68,7 +68,7 @@ describe OtherCollectionsController do
       collection.apply_depositor_metadata(@user.user_key)
       collection.members = [asset1,asset2,asset3]
       collection.save
-      controller.stub(:apply_gated_search)
+      allow(controller).to receive(:apply_gated_search)
     end
     after do
       Rails.application.reload_routes!
@@ -76,11 +76,11 @@ describe OtherCollectionsController do
     it "should show the collections" do
       routes.draw { resources :other_collections, except: :index }
       get :show, id: collection.id
-      assigns[:collection].title.should == collection.title
+      expect(assigns[:collection].title).to eq(collection.title)
       ids = assigns[:member_docs].map {|d| d.id}
-      ids.should include asset1.pid
-      ids.should include asset2.pid
-      ids.should include asset3.pid
+      expect(ids).to include asset1.pid
+      expect(ids).to include asset2.pid
+      expect(ids).to include asset3.pid
     end
   end
 

--- a/spec/controllers/selects_collections_spec.rb
+++ b/spec/controllers/selects_collections_spec.rb
@@ -10,15 +10,15 @@ class SelectsCollectionsController < ApplicationController
 end
 
 
-describe SelectsCollectionsController do
+describe SelectsCollectionsController, :type => :controller do
 
   describe "#find_collections" do
     it "should override solr_search_params_logic to use collection_search_params_logic, then switch it back" do
       # Looks like we can only test this indirectly b/c blacklight doesn't let you explicitly pass solr_search_params_logic when running searches -- you have to set the controller's solr_search_params_logic class attribute
       original_solr_logic = subject.solr_search_params_logic
-      subject.collection_search_params_logic.should == [:default_solr_parameters, :add_query_to_solr, :add_access_controls_to_solr_params, :add_collection_filter]
-      subject.class.should_receive(:solr_search_params_logic=).with(subject.collection_search_params_logic)
-      subject.class.should_receive(:solr_search_params_logic=).with(original_solr_logic)
+      expect(subject.collection_search_params_logic).to eq([:default_solr_parameters, :add_query_to_solr, :add_access_controls_to_solr_params, :add_collection_filter])
+      expect(subject.class).to receive(:solr_search_params_logic=).with(subject.collection_search_params_logic)
+      expect(subject.class).to receive(:solr_search_params_logic=).with(original_solr_logic)
       subject.find_collections
     end
   end
@@ -60,15 +60,15 @@ describe SelectsCollectionsController do
         expect(@user_collections).to be_kind_of(Array)
       end
       it "should return public collections" do
-        @user_collections.index{|d| d.id == @collection.id}.should_not be_nil
+        expect(@user_collections.index{|d| d.id == @collection.id}).not_to be_nil
       end
       it "should return all public collections" do
-        @user_collections.count.should == 12
+        expect(@user_collections.count).to eq(12)
       end
       it "should not return non public collections" do
-        @user_collections.index{|d| d.id == @collection2.id}.should be_nil
-        @user_collections.index{|d| d.id == @collection3.id}.should be_nil
-        @user_collections.index{|d| d.id == @collection4.id}.should be_nil
+        expect(@user_collections.index{|d| d.id == @collection2.id}).to be_nil
+        expect(@user_collections.index{|d| d.id == @collection3.id}).to be_nil
+        expect(@user_collections.index{|d| d.id == @collection4.id}).to be_nil
        end
     end
     describe "Read Access" do
@@ -85,12 +85,12 @@ describe SelectsCollectionsController do
           expect(@user_collections).to be_kind_of(Array)
         end
         it "should return public and read access (edit access implies read) collections" do
-          @user_collections.index{|d| d.id == @collection.id}.should_not be_nil
-          @user_collections.index{|d| d.id == @collection2.id}.should_not be_nil
-          @user_collections.index{|d| d.id == @collection3.id}.should_not be_nil
+          expect(@user_collections.index{|d| d.id == @collection.id}).not_to be_nil
+          expect(@user_collections.index{|d| d.id == @collection2.id}).not_to be_nil
+          expect(@user_collections.index{|d| d.id == @collection3.id}).not_to be_nil
         end 
         it "should not return non public collections" do
-          @user_collections.index{|d| d.id == @collection4.id}.should be_nil
+          expect(@user_collections.index{|d| d.id == @collection4.id}).to be_nil
         end
       end
     end
@@ -108,12 +108,12 @@ describe SelectsCollectionsController do
            expect(@user_collections).to be_kind_of(Array)
          end
         it "should return public or editable collections" do
-          @user_collections.index{|d| d.id == @collection.id}.should_not be_nil
-          @user_collections.index{|d| d.id == @collection3.id}.should_not be_nil
+          expect(@user_collections.index{|d| d.id == @collection.id}).not_to be_nil
+          expect(@user_collections.index{|d| d.id == @collection3.id}).not_to be_nil
         end 
         it "should not return non public or editable collections" do
-          @user_collections.index{|d| d.id == @collection2.id}.should be_nil
-          @user_collections.index{|d| d.id == @collection4.id}.should be_nil
+          expect(@user_collections.index{|d| d.id == @collection2.id}).to be_nil
+          expect(@user_collections.index{|d| d.id == @collection4.id}).to be_nil
         end
       end
     end

--- a/spec/helpers/collections_helper_spec.rb
+++ b/spec/helpers/collections_helper_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 include Hydra::Collections::Engine.routes.url_helpers
 
-describe CollectionsHelper do
+describe CollectionsHelper, :type => :helper do
   describe "button_for_create_collection" do
     it " should create a button to the collections new path" do
       str = String.new(helper.button_for_create_collection)
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.new_collection_path}"
+      expect(form.attr('action')).to eq("#{collections.new_collection_path}")
       i = form.children.first.children.first
-      i.attr('type').should == 'submit'
+      expect(i.attr('type')).to eq('submit')
     end
     it "should create a button with my text" do
       str = String.new(helper.button_for_create_collection "Create My Button")
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.new_collection_path}"
+      expect(form.attr('action')).to eq("#{collections.new_collection_path}")
       i = form.children.first.children.first
-      i.attr('value').should == 'Create My Button'
+      expect(i.attr('value')).to eq('Create My Button')
     end
   end
   describe "button_for_delete_collection" do
@@ -32,17 +32,17 @@ describe CollectionsHelper do
       str = button_for_delete_collection @collection
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
+      expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
       i = form.children.first.children[1]
-      i.attr('type').should == 'submit'
+      expect(i.attr('type')).to eq('submit')
     end
     it "should create a button with my text" do
       str = button_for_delete_collection @collection, "Delete My Button"
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
+      expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
       i = form.children.first.children[1]
-      i.attr('value').should == "Delete My Button"
+      expect(i.attr('value')).to eq("Delete My Button")
     end
   end
   describe "button_for_remove_from_collection" do
@@ -55,9 +55,9 @@ describe CollectionsHelper do
       str = button_for_remove_from_collection item
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
-      form.css('input#collection_members[type="hidden"][value="remove"]').should_not be_empty
-      form.css('input[type="hidden"][name="batch_document_ids[]"][value="changeme:123"]').should_not be_empty
+      expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
+      expect(form.css('input#collection_members[type="hidden"][value="remove"]')).not_to be_empty
+      expect(form.css('input[type="hidden"][name="batch_document_ids[]"][value="changeme:123"]')).not_to be_empty
     end
 
     describe "for a collection of another name" do
@@ -77,9 +77,9 @@ describe CollectionsHelper do
         str = button_for_remove_from_collection item
         doc = Nokogiri::HTML(str)
         form = doc.xpath('//form').first
-        form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
-        form.css('input#collection_members[type="hidden"][value="remove"]').should_not be_empty
-        form.css('input[type="hidden"][name="batch_document_ids[]"][value="changeme:123"]').should_not be_empty
+        expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
+        expect(form.css('input#collection_members[type="hidden"][value="remove"]')).not_to be_empty
+        expect(form.css('input[type="hidden"][name="batch_document_ids[]"][value="changeme:123"]')).not_to be_empty
       end
 
     end
@@ -95,18 +95,18 @@ describe CollectionsHelper do
       str = button_for_remove_selected_from_collection @collection
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
+      expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
       i = form.children[2]
-      i.attr('value').should == "remove"
-      i.attr('name').should == "collection[members]"
+      expect(i.attr('value')).to eq("remove")
+      expect(i.attr('name')).to eq("collection[members]")
     end
     it "should create a button with my text" do
       str = button_for_remove_selected_from_collection @collection, "Remove My Button"
       doc = Nokogiri::HTML(str)
       form = doc.xpath('//form').first
-      form.attr('action').should == "#{collections.collection_path(@collection.pid)}"
+      expect(form.attr('action')).to eq("#{collections.collection_path(@collection.pid)}")
       i = form.children[3]
-      i.attr('value').should == "Remove My Button"
+      expect(i.attr('value')).to eq("Remove My Button")
     end
   end
 
@@ -115,9 +115,9 @@ describe CollectionsHelper do
     it "should make hidden fields" do
       doc = Nokogiri::HTML(hidden_collection_members)
       inputs = doc.xpath('//input[@type="hidden"][@name="batch_document_ids[]"]')
-      inputs.length.should == 2
-      inputs[0].attr('value').should == 'foo:12'
-      inputs[1].attr('value').should == 'foo:23'
+      expect(inputs.length).to eq(2)
+      expect(inputs[0].attr('value')).to eq('foo:12')
+      expect(inputs[1].attr('value')).to eq('foo:23')
     end
   end
 

--- a/spec/helpers/collections_search_helper_spec.rb
+++ b/spec/helpers/collections_search_helper_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe CollectionsSearchHelper do
+describe CollectionsSearchHelper, :type => :helper do
   describe "collection_name" do
     let (:collection_without_title) { Collection.create() }
     let (:collection_with_title) { Collection.create(title: "Title of Collection 2") }
     it "should return the pid if no title available" do
-      collection_name(collection_without_title.pid).should == collection_without_title.pid
+      expect(collection_name(collection_without_title.pid)).to eq(collection_without_title.pid)
     end
     it "should return the title value associated with the given pid" do
-      collection_name(collection_with_title.pid).should == "Title of Collection 2"
+      expect(collection_name(collection_with_title.pid)).to eq("Title of Collection 2")
     end
   end
 end

--- a/spec/lib/collectible_spec.rb
+++ b/spec/lib/collectible_spec.rb
@@ -16,8 +16,8 @@ describe Hydra::Collections::Collectible do
       @collection1.save
       @collectible.collections << @collection2
       reloaded = CollectibleThing.find(@collectible.pid)
-      @collection2.reload.members.should == [@collectible]
-      reloaded.collections.should == [@collection1, @collection2]
+      expect(@collection2.reload.members).to eq([@collectible])
+      expect(reloaded.collections).to eq([@collection1, @collection2])
     end
   end
   describe "index_collection_pids" do
@@ -25,7 +25,7 @@ describe Hydra::Collections::Collectible do
       @collectible.save
       @collectible.collections << @collection1
       @collectible.collections << @collection2
-      @collectible.index_collection_pids["collection_sim"].should == [@collection1.pid, @collection2.pid]
+      expect(@collectible.index_collection_pids["collection_sim"]).to eq([@collection1.pid, @collection2.pid])
     end
   end
 end

--- a/spec/lib/search_service_spec.rb
+++ b/spec/lib/search_service_spec.rb
@@ -8,19 +8,19 @@ describe Hydra::Collections::SearchService do
   end
 
   it "should get the documents for the first history entry" do
-    Search.should_receive(:find).with(17).and_return(Search.new(:query_params=>{:q=>"World Peace"}))
-    @service.should_receive(:get_search_results).and_return([:one, [:doc1, :doc2]])
-    @service.last_search_documents.should == [:doc1, :doc2]
+    expect(Search).to receive(:find).with(17).and_return(Search.new(:query_params=>{:q=>"World Peace"}))
+    expect(@service).to receive(:get_search_results).and_return([:one, [:doc1, :doc2]])
+    expect(@service.last_search_documents).to eq([:doc1, :doc2])
   end
 
   describe 'apply_gated_search' do
     before(:each) do
-      RoleMapper.stub(:roles).with(@login).and_return(['umg/test.group.1'])
+      allow(RoleMapper).to receive(:roles).with(@login).and_return(['umg/test.group.1'])
       params = @service.apply_gated_search({}, {})
       @group_query = params[:fq].first.split(' OR ')[1]
     end
     it "should escape slashes in groups" do
-      @group_query.should == 'edit_access_group_ssim:umg\/test.group.1'
+      expect(@group_query).to eq('edit_access_group_ssim:umg\/test.group.1')
     end
     it "should allow overriding Solr's access control suffix" do
       module Hydra
@@ -35,7 +35,7 @@ describe Hydra::Collections::SearchService do
       @service = Hydra::Collections::SearchService.new({}, '')
       params = @service.apply_gated_search({}, {})
       @public_query = params[:fq].first.split(' OR ')[0]
-      @public_query.should == 'edit_group_customfield:public'
+      expect(@public_query).to eq('edit_group_customfield:public')
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -14,7 +14,7 @@
 
 require 'spec_helper'
 
-describe Collection do
+describe Collection, :type => :model do
   before(:all) do
     @user = FactoryGirl.find_or_create(:user)
     class GenericFile < ActiveFedora::Base
@@ -45,20 +45,20 @@ describe Collection do
     @gf2.destroy
   end
   it "should have a depositor" do
-    @collection.depositor.should == @user.user_key
+    expect(@collection.depositor).to eq(@user.user_key)
   end
   it "should allow the depositor to edit and read" do
     ability = Ability.new(@user)
-    ability.can?(:read, @collection).should  == true
-    ability.can?(:edit, @collection).should  == true
+    expect(ability.can?(:read, @collection)).to  eq(true)
+    expect(ability.can?(:edit, @collection)).to  eq(true)
   end
   it "should be empty by default" do
-    @collection.members.should be_empty
+    expect(@collection.members).to be_empty
   end
   it "should have many files" do
     @collection.members = [@gf1, @gf2]
     @collection.save
-    Collection.find(@collection.pid).members.should == [@gf1, @gf2]
+    expect(Collection.find(@collection.pid).members).to eq([@gf1, @gf2])
   end
   it "should allow new files to be added" do
     @collection.members = [@gf1]
@@ -66,58 +66,58 @@ describe Collection do
     @collection = Collection.find(@collection.pid)
     @collection.members << @gf2
     @collection.save
-    Collection.find(@collection.pid).members.should == [@gf1, @gf2]
+    expect(Collection.find(@collection.pid).members).to eq([@gf1, @gf2])
   end
   it "should allow files to be removed" do
     @collection.members = [@gf1, @gf2]
     @collection.save
     solr_doc_before_remove = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @gf1.pid).send(:solr_doc)
-    solr_doc_before_remove["collection_tesim"].should == [@collection.pid]
+    expect(solr_doc_before_remove["collection_tesim"]).to eq([@collection.pid])
     @collection.reload.members.delete(@gf1)
     @collection.save
-    Collection.find(@collection.pid).members.should == [@gf2]
+    expect(Collection.find(@collection.pid).members).to eq([@gf2])
     solr_doc_after_remove = ActiveFedora::SolrInstanceLoader.new(ActiveFedora::Base, @gf1.pid).send(:solr_doc)
-    solr_doc_after_remove["collection_tesim"].should be_nil
+    expect(solr_doc_after_remove["collection_tesim"]).to be_nil
   end
   it "should set the date uploaded on create" do
     @collection.save
-    @collection.date_uploaded.should be_kind_of(Date)
+    expect(@collection.date_uploaded).to be_kind_of(Date)
   end
   it "should update the date modified on update" do
     uploaded_date = Date.today
     modified_date = Date.tomorrow
-    Date.stub(:today).and_return(uploaded_date, modified_date)
+    allow(Date).to receive(:today).and_return(uploaded_date, modified_date)
     @collection.save
-    @collection.date_modified.should == uploaded_date
+    expect(@collection.date_modified).to eq(uploaded_date)
     @collection.members = [@gf1]
     @collection.save
-    @collection.date_modified.should == modified_date
+    expect(@collection.date_modified).to eq(modified_date)
     @gf1 = @gf1.reload
-    @gf1.collections.should include(@collection)
-    @gf1.to_solr[Solrizer.solr_name(:collection)].should == [@collection.id]
+    expect(@gf1.collections).to include(@collection)
+    expect(@gf1.to_solr[Solrizer.solr_name(:collection)]).to eq([@collection.id])
   end
   it "should have a title" do
     @collection.title = "title"
     @collection.save
-    Collection.find(@collection.pid).title.should == @collection.title
+    expect(Collection.find(@collection.pid).title).to eq(@collection.title)
   end
   it "should have a description" do
     @collection.description = "description"
     @collection.save
-    Collection.find(@collection.pid).description.should == @collection.description
+    expect(Collection.find(@collection.pid).description).to eq(@collection.description)
   end
   it "should have the expected display terms" do
-    @collection.terms_for_display.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :date_created, :date_uploaded, :date_modified, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url]
+    expect(@collection.terms_for_display).to eq([:part_of, :contributor, :creator, :title, :description, :publisher, :date_created, :date_uploaded, :date_modified, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url])
   end
   it "should have the expected edit terms" do
-    @collection.terms_for_editing.should == [:part_of, :contributor, :creator, :title, :description, :publisher, :date_created, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url]
+    expect(@collection.terms_for_editing).to eq([:part_of, :contributor, :creator, :title, :description, :publisher, :date_created, :subject, :language, :rights, :resource_type, :identifier, :based_near, :tag, :related_url])
   end
   it "should not delete member files when deleted" do
     @collection.members = [@gf1, @gf2]
     @collection.save
     @collection.destroy
-    GenericFile.exists?(@gf1.pid).should be_true
-    GenericFile.exists?(@gf2.pid).should be_true
+    expect(GenericFile.exists?(@gf1.pid)).to be_truthy
+    expect(GenericFile.exists?(@gf2.pid)).to be_truthy
   end
 
   describe "Collection by another name" do
@@ -141,7 +141,7 @@ describe Collection do
       collection.members << member
       collection.save
       member.reload
-      member.collections.should == [collection]
+      expect(member.collections).to eq([collection])
       collection.destroy
       member.destroy
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,6 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, :type => :controller
   config.before(:each, :type=>"controller") { @routes = Hydra::Collections::Engine.routes }
   config.include EngineRoutes, :type => :controller
-  config.infer_spec_type_from_file_location!
 end
 
 module FactoryGirl


### PR DESCRIPTION
Updates tests to Rspec version 3.  I also wanted to get rid of this warning:

```
DEPRECATION WARNING: In active-fedora 8 the solr fields created by Hydra::Datastream::Properties will be prefixed with "properties__".  If you want to maintain the existing behavior, you must override Hydra::Datastream::Properties.#prefix to return an empty string. (called from to_solr at /Users/awead/.gem/ruby/2.1.1/gems/active-fedora-7.1.0/lib/active_fedora/om_datastream.rb:51)
```

But that would require an update to Hydra.  So I'm leaving that one warning in there for now.
