### PR TITLE
Only index the relationship in the collection.

### DIFF
--- a/app/controllers/concerns/hydra/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hydra/collections_controller_behavior.rb
@@ -175,7 +175,7 @@ module Hydra
     # include filters into the query to only include the collection memebers
     def include_collection_ids(solr_parameters, user_parameters)
       solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << Solrizer.solr_name(:collection, :facetable)+':"'+@collection.id+'"'
+      solr_parameters[:fq] << "{!join from=hasCollectionMember_ssim to=id}id:#{@collection.id}"
     end
   end # module CollectionsControllerBehavior
 end # module Hydra

--- a/app/models/concerns/hydra/collection.rb
+++ b/app/models/concerns/hydra/collection.rb
@@ -2,12 +2,13 @@ module Hydra
   module Collection
     extend ActiveSupport::Concern
     extend ActiveSupport::Autoload
+    extend Deprecation
     include Hydra::WithDepositor # for access to apply_depositor_metadata
     include Hydra::AccessControls::Permissions
     include Hydra::Collections::Collectible
 
     included do
-      has_and_belongs_to_many :members, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasCollectionMember, class_name: "ActiveFedora::Base" , after_remove: :update_member
+      has_and_belongs_to_many :members, predicate: ActiveFedora::RDF::Fcrepo::RelsExt.hasCollectionMember, class_name: "ActiveFedora::Base"
 
       property :depositor, predicate: ::RDF::URI.new("http://id.loc.gov/vocabulary/relators/dpt"), multiple: false do |index|
         index.as :symbol, :stored_searchable
@@ -66,17 +67,16 @@ module Hydra
 
       before_create :set_date_uploaded
       before_save :set_date_modified
-      before_destroy :update_all_members
-
-      after_save :update_all_members
     end
 
     def update_all_members
+      Deprecation.warn(Collection, 'update_all_members is deprecated and will be removed in version 5.0')
       self.members.collect { |m| update_member(m) }
     end
 
     # TODO: Use solr atomic updates to accelerate this process
     def update_member member
+      Deprecation.warn(Collection, 'update_member is deprecated and will be removed in version 5.0')
       # because the member may have its collections cached, reload that cache so that it indexes the correct fields.
       member.collections(true) if member.respond_to? :collections
       member.update_index

--- a/lib/hydra/collections/collectible.rb
+++ b/lib/hydra/collections/collectible.rb
@@ -19,6 +19,7 @@ module Hydra::Collections::Collectible
   #    return solr_doc
   #   end
   def index_collection_ids(solr_doc={})
+    Deprecation.warn(Hydra::Collections::Collectible, 'index_collection_ids is deprecated and will be removed in version 5.0')
     # CollectionAssociation#ids_reader loads from solr on each call, so only call it once
     # see https://github.com/projecthydra/active_fedora/issues/644
     ids = collection_ids

--- a/spec/controllers/other_collections_controller_spec.rb
+++ b/spec/controllers/other_collections_controller_spec.rb
@@ -13,24 +13,11 @@ end
 class OtherCollection < ActiveFedora::Base
   include Hydra::Collection
   include Hydra::Collections::Collectible
-
-  def to_solr(solr_doc={})
-    super.tap do |solr_doc|
-      index_collection_ids(solr_doc)
-    end
-  end
 end
 
 class Member < ActiveFedora::Base
   include Hydra::Collections::Collectible
   attr_accessor :title
-
-  def to_solr(solr_doc={})
-    super.tap do |solr_doc|
-      index_collection_ids(solr_doc)
-    end
-  end
-
 end
 
 # make sure a collection by another name still assigns the @collection variable

--- a/spec/lib/collectible_spec.rb
+++ b/spec/lib/collectible_spec.rb
@@ -25,6 +25,7 @@ describe Hydra::Collections::Collectible do
       @collectible.save
       @collectible.collections << @collection1
       @collectible.collections << @collection2
+      expect(Deprecation).to receive(:warn)
       expect(@collectible.index_collection_ids["collection_sim"]).to eq [@collection1.id, @collection2.id]
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require 'coveralls'
-Coveralls.wear!
+if ENV['CI']
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Previously adding a new member to the collection caused every member of
the collection to get reindexed. This becomes impractical for large
collections. For example, adding a new member to a 500 member collection
causes 502 writes to solr.

This is a breaking change if you've overridden anything that
hydra-collections does, so it will require us to release 5.0.
