### PR TITLE
Remove the before_save/create actions that set dates

### DIFF
--- a/app/models/concerns/hydra/collection.rb
+++ b/app/models/concerns/hydra/collection.rb
@@ -9,7 +9,6 @@ module Hydra
     include Hydra::Collections::Collectible
     include Hydra::Collections::Metadata
     include Hydra::Collections::Relations
-    include Hydra::Collections::Actions
 
     def update_all_members
       Deprecation.warn(Collection, 'update_all_members is deprecated and will be removed in version 5.0')

--- a/app/models/concerns/hydra/collections/actions.rb
+++ b/app/models/concerns/hydra/collections/actions.rb
@@ -3,6 +3,7 @@ module Hydra::Collections
     extend ActiveSupport::Concern
 
     included do
+      Deprecation.warn(Actions, "Hydra::Collections::Actions is deprecated and will be removed in 6.0.0")
       before_create :set_date_uploaded
       before_save :set_date_modified
     end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -106,28 +106,6 @@ describe Collection, :type => :model do
     end
   end
 
-  it "should set the date uploaded on create" do
-    subject.save
-    expect(subject.date_uploaded).to be_kind_of(Date)
-  end
-
-  describe "when updating" do
-    let(:gf1) { GenericFile.create }
-
-    it "should update the date modified on update" do
-      uploaded_date = Date.today
-      modified_date = Date.tomorrow
-      subject.save
-      allow(Date).to receive(:today).and_return(uploaded_date, modified_date)
-      subject.save
-      expect(subject.date_modified).to eq uploaded_date
-      subject.members = [gf1]
-      subject.save
-      expect(subject.date_modified).to eq modified_date
-      expect(gf1.reload.collections).to include(subject)
-    end
-  end
-
   it "should have a title" do
     subject.title = "title"
     subject.save


### PR DESCRIPTION
This functionality is duplicate of what ActiveFedora is already doing
with the `create_date` and `modified_date` properties
