### PR TITLE
Extract methods from SearchBuilder into Search behaviors

### DIFF
--- a/app/search_builders/hydra/collections/search_builder.rb
+++ b/app/search_builders/hydra/collections/search_builder.rb
@@ -1,31 +1,5 @@
 module Hydra::Collections
   class SearchBuilder < Hydra::SearchBuilder
-
-    def collection
-      scope.collection
-    end
-
-    # include filters into the query to only include the collection memebers
-    def include_collection_ids(solr_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << "{!join from=hasCollectionMember_ssim to=id}id:#{collection.id}"
-    end
-
-    def some_rows(solr_parameters)
-      solr_parameters[:rows] = '100'
-    end
-
-    def add_collection_filter(solr_parameters)
-      solr_parameters[:fq] ||= []
-      solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::Collection.to_class_uri)
-    end
-
-    def discovery_perms= perms
-      @discovery_perms = perms
-    end
-
-    def discovery_permissions
-      @discovery_perms || super
-    end
+    include Hydra::Collections::SearchBehaviors
   end
 end

--- a/lib/hydra-collections.rb
+++ b/lib/hydra-collections.rb
@@ -9,6 +9,7 @@ module Hydra
     autoload :AcceptsBatches
     autoload :SelectsCollections
     autoload :SolrDocumentBehavior
+    autoload :SearchBehaviors
     class Engine < ::Rails::Engine
       engine_name "collections"
       config.autoload_paths += %W(

--- a/lib/hydra/collections/search_behaviors.rb
+++ b/lib/hydra/collections/search_behaviors.rb
@@ -1,0 +1,30 @@
+module Hydra::Collections::SearchBehaviors
+
+  def collection
+    scope.collection
+  end
+
+  # include filters into the query to only include the collection memebers
+  def include_collection_ids(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << "{!join from=hasCollectionMember_ssim to=id}id:#{collection.id}"
+  end
+
+  def some_rows(solr_parameters)
+    solr_parameters[:rows] = '100'
+  end
+
+  def add_collection_filter(solr_parameters)
+    solr_parameters[:fq] ||= []
+    solr_parameters[:fq] << ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::Collection.to_class_uri)
+  end
+
+  def discovery_perms= perms
+    @discovery_perms = perms
+  end
+
+  def discovery_permissions
+    @discovery_perms || super
+  end
+
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-include Rails.application.routes.url_helpers
-
 describe CatalogController, :type => :controller do
 
   before do

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -71,7 +71,7 @@ class TestAppGenerator < Rails::Generators::Base
   
   # Inject collections call into balacklight catalog
   def inject_collections
-    insert_into_file "app/controllers/catalog_controller.rb", :after => 'Hydra::Controller::ControllerBehavior' do
+    insert_into_file "app/controllers/catalog_controller.rb", :after => 'Hydra::Catalog' do
       "\n  include Hydra::Collections::SelectsCollections\n  before_filter :find_collections, :only=>:index"
     end
   end


### PR DESCRIPTION
This makes things friendlier when Blacklight 6.0 is released. Users may now create their own search builder classes and include Hydra::Collections::SearchBehaviors, overriding as needed.
