### PR TITLE
add ability to prepend instructions to list of editable collections (5.0-stable branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ notifications:
       - "irc.freenode.org#projecthydra"
     template:
       - "%{repository}//%{branch}@%{commit} by %{author}: %{message} - %{build_url}"
+before_script:
+  - jdk_switcher use oraclejdk8

--- a/app/controllers/concerns/hydra/collections/selects_collections.rb
+++ b/app/controllers/concerns/hydra/collections/selects_collections.rb
@@ -11,16 +11,35 @@ module Hydra::Collections::SelectsCollections
     { read: [:read, :edit], edit: [:edit] }
   end
 
-  # add one of the following methods as a before filter on any page that shows the form_for_select_collection
+  ##
+  # Return list of collections for which the current user has read access.
+  # Add this or find_collections_with_edit_access as a before filter on any page that shows the form_for_select_collection
+  #
+  # @return [Array<SolrDocument>] Solr documents for each collection the user has read access
   def find_collections_with_read_access
     find_collections(:read)
   end
 
-  def find_collections_with_edit_access
+  ##
+  # Return list of collections for which the current user has edit access.  Optionally prepend with default
+  # that can be used in a select menu to instruct user to select a collection.
+  # Add this or find_collections_with_read_access as a before filter on any page that shows the form_for_select_collection
+  #
+  # @param [TrueClass|FalseClass] :include_default if true, prepends the default_option; otherwise, if false, returns only collections
+  # @param [Fixnum] :default_id for select menus, this is the id of the first selection representing the instructions
+  # @param [String] :default_title for select menus, this is the text displayed as the first item serving as instructions
+  #
+  # @return [Array<SolrDocument>] Solr documents for each collection the user has edit access, plus optional instructions
+  def find_collections_with_edit_access(include_default=false, default_id=-1, default_title="Select collection...")
     find_collections(:edit)
+    default_option = SolrDocument.new(id: default_id, title_tesim: default_title)
+    @user_collections.unshift(default_option) if include_default
   end
 
-  #
+  ##
+  # Return list of collections matching the passed in access_level for the current user.
+  # @param [Symbol] :access_level one of :read or :edit
+  # @return [Array<SolrDocument>] Solr documents for each collection the user has the appropriate access level
   def find_collections (access_level = nil)
     # need to know the user if there is an access level applied otherwise we are just doing public collections
     authenticate_user! unless access_level.blank?

--- a/app/controllers/concerns/hydra/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hydra/collections_controller_behavior.rb
@@ -172,7 +172,7 @@ module Hydra
 
     def add_members_to_collection collection = nil
       collection ||= @collection
-      collection.member_ids = batch.concat(collection.member_ids)
+      collection.add_members batch
     end
 
     def remove_members_from_collection

--- a/app/models/concerns/hydra/collection.rb
+++ b/app/models/concerns/hydra/collection.rb
@@ -21,5 +21,9 @@ module Hydra
       member.update_index
     end
 
+    def add_members new_member_ids
+      return if new_member_ids.nil? || new_member_ids.size < 1
+      self.members << ActiveFedora::Base.find(new_member_ids)
+    end
  end
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -72,7 +72,7 @@ describe CollectionsController, :type => :controller do
       @asset1 = ActiveFedora::Base.create!
       @asset2 = ActiveFedora::Base.create!
       post :create, batch_document_ids: [@asset1, @asset2], collection: {title: "My Secong Collection ", description: "The Description\r\n\r\nand more"}
-      expect(assigns[:collection].members).to eq([@asset1, @asset2])
+      expect(assigns[:collection].members).to match_array [@asset1, @asset2]
     end
     it "should call after_create" do
        expect(controller).to receive(:after_create).and_call_original
@@ -94,7 +94,7 @@ describe CollectionsController, :type => :controller do
       @asset1 = GenericFile.create!
       @asset2 = GenericFile.create!
       post :create, batch_document_ids: [@asset1,@asset2], collection: {title: "My Secong Collection ", description: "The Description\r\n\r\nand more"}
-      expect(assigns[:collection].members).to eq([@asset1,@asset2])
+      expect(assigns[:collection].members).to match_array [@asset1, @asset2]
       asset_results = ActiveFedora::SolrService.instance.conn.get "select", params:{fq:["id:\"#{@asset1.id}\""],fl:['id',Solrizer.solr_name(:collection)]}
       expect(asset_results["response"]["numFound"]).to eq(1)
       doc = asset_results["response"]["docs"].first

--- a/spec/controllers/selects_collections_spec.rb
+++ b/spec/controllers/selects_collections_spec.rb
@@ -91,6 +91,11 @@ describe SelectsCollectionsController, :type => :controller do
           subject.find_collections_with_edit_access
           expect(assigns[:user_collections].map(&:id)).to match_array [@collection.id, @collection3.id]
         end
+
+        it "should return only public or editable collections & instructions" do
+          subject.find_collections_with_edit_access(true)
+          expect(assigns[:user_collections].map(&:id)).to match_array [-1, @collection.id, @collection3.id]
+        end
       end
     end
   end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -14,6 +14,7 @@ describe Collection, :type => :model do
 
   let(:gf1) { GenericFile.create }
   let(:gf2) { GenericFile.create }
+  let(:gf3) { GenericFile.create }
 
   let(:user) { @user }
 
@@ -71,7 +72,7 @@ describe Collection, :type => :model do
         subject { Collection.create(members: [gf1, gf2]) }
 
         it "should have many files" do
-          expect(subject.reload.members).to eq [gf1, gf2]
+          expect(subject.reload.members).to match_array [gf1, gf2]
         end
       end
 
@@ -84,7 +85,14 @@ describe Collection, :type => :model do
           subject.reload
           subject.members << gf2
           subject.save
-          expect(subject.reload.members).to eq [gf1, gf2]
+          expect(subject.reload.members).to match_array [gf1, gf2]
+        end
+
+        it "should allow multiple files to be added" do
+          subject.reload
+          subject.add_members [gf2.id, gf3.id]
+          subject.save
+          expect(subject.reload.members).to match_array [gf1, gf2, gf3]
         end
       end
     end


### PR DESCRIPTION
Additional work done in this PR
- Fixed Travis:  use jdk8 to be able to work with latest jetty
- Fixed 3 tests:  all failed due to order which doesn't matter 
