### PR TITLE
Pass the document_counter to index_default

### DIFF
--- a/app/views/collections/_index_default.html.erb
+++ b/app/views/collections/_index_default.html.erb
@@ -1,2 +1,2 @@
-<%= render 'catalog/index_default', document: document %>
+<%= render 'catalog/index_default', document: document, document_counter: document_counter %>
 

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,1 +1,2 @@
 gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
+gem 'active-fedora', github: 'projecthydra/active_fedora'


### PR DESCRIPTION
document_counter is not used by the blackight version of index_default,
but it is used by the curation_concerns version of index_default.
