### PR TITLE
Don't cache the SearchBuilder

### DIFF
--- a/app/controllers/concerns/hydra/collections/selects_collections.rb
+++ b/app/controllers/concerns/hydra/collections/selects_collections.rb
@@ -57,7 +57,7 @@ module Hydra::Collections::SelectsCollections
   end
 
   def collections_search_builder(access_level = nil)
-    @collections_search_builder ||= collections_search_builder_class.new(collection_search_params_logic, self).tap do |builder|
+    collections_search_builder_class.new(collection_search_params_logic, self).tap do |builder|
       builder.current_ability = current_ability
       builder.discovery_perms = access_levels[access_level] if access_level
     end

--- a/spec/controllers/selects_collections_spec.rb
+++ b/spec/controllers/selects_collections_spec.rb
@@ -86,14 +86,25 @@ describe SelectsCollectionsController, :type => :controller do
       describe "signed in" do
         before { sign_in @user }
 
-        it "should return only public or editable collections" do
+        it "returns only public or editable collections" do
           subject.find_collections_with_edit_access
           expect(assigns[:user_collections].map(&:id)).to match_array [@collection.id, @collection3.id]
         end
 
-        it "should return only public or editable collections & instructions" do
+        it "returns only public or editable collections & instructions" do
           subject.find_collections_with_edit_access(true)
           expect(assigns[:user_collections].map(&:id)).to match_array [-1, @collection.id, @collection3.id]
+        end
+
+        context "after querying for read access" do
+          before do
+            subject.find_collections
+            subject.find_collections_with_edit_access
+          end
+
+          it "returns collections with edit access" do
+            expect(assigns[:user_collections].map(&:id)).to match_array [@collection.id, @collection3.id]
+          end
         end
       end
     end


### PR DESCRIPTION
The cache wasn't invalidated when the access level was changed.

Caused this error: https://github.com/projecthydra-labs/sufia-core/pull/331
